### PR TITLE
Fix indentation for deploy_to_pi job in CI workflow

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -95,7 +95,7 @@ jobs:
           path: backend/publish_output/**
           if-no-files-found: error
 
-deploy_to_pi:
+  deploy_to_pi:
     needs: build_test_analyze
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest


### PR DESCRIPTION
Corrected the indentation of the deploy_to_pi job in ci-backend.yml to ensure proper job recognition and execution in GitHub Actions.